### PR TITLE
Refatorei o DeepResearchOrchestrator para isolar a memória do agente,…

### DIFF
--- a/src/pro_vida/orchestrator.py
+++ b/src/pro_vida/orchestrator.py
@@ -10,12 +10,11 @@ logger = logging.getLogger(__name__)
 # Define o estado do grafo
 class AgentState(TypedDict):
     topic: str
-    research_results: Annotated[List[dict], operator.add]
+    research_results: List[dict]
 
 class DeepResearchOrchestrator:
     def __init__(self):
         self.research_agent = ResearchAgent()
-        self.workflow = self._build_graph()
 
     def _build_graph(self):
         """Constrói o grafo de orquestração com LangGraph."""
@@ -46,10 +45,13 @@ class DeepResearchOrchestrator:
     def run(self, topic: str):
         """Inicia a execução do fluxo de pesquisa profunda."""
         logger.info(f"Iniciando orquestrador para o tópico: {topic}")
-        initial_state = {"topic": topic, "research_results": []}
+
+        workflow = self._build_graph()
+
+        initial_state = {"topic": topic}
 
         # O LangGraph gerencia a execução dos nós.
-        final_state = self.workflow.invoke(initial_state)
+        final_state = workflow.invoke(initial_state)
 
         logger.info("Orquestração concluída.")
-        return final_state
+        return final_state.get("research_results", [])

--- a/src/pro_vida/tests/test_orchestrator.py
+++ b/src/pro_vida/tests/test_orchestrator.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock
+
+class TestDeepResearchOrchestrator(unittest.TestCase):
+
+    @patch.dict(os.environ, {"GOOGLE_API_KEY": "test_key"})
+    @patch('src.pro_vida.orchestrator.ResearchAgent')
+    def test_run_isolates_state(self, MockResearchAgent):
+        from src.pro_vida.orchestrator import DeepResearchOrchestrator
+        # Crie uma instância mock do ResearchAgent
+        mock_agent_instance = MockResearchAgent.return_value
+
+        # Configure o mock para retornar resultados de pesquisa diferentes para diferentes tópicos
+        async def mock_search_web(topic):
+            if topic == "topic1":
+                return [{"result": "topic1_result"}]
+            elif topic == "topic2":
+                return [{"result": "topic2_result"}]
+            return []
+
+        mock_agent_instance.search_web = MagicMock(side_effect=mock_search_web)
+
+        # Crie o orquestrador
+        orchestrator = DeepResearchOrchestrator()
+
+        # Execute o orquestrador com o primeiro tópico
+        results1 = orchestrator.run("topic1")
+
+        # Execute o orquestrador com o segundo tópico
+        results2 = orchestrator.run("topic2")
+
+        # Verifique se os resultados são os esperados e não são combinados
+        self.assertEqual(results1, [{"result": "topic1_result"}])
+        self.assertEqual(results2, [{"result": "topic2_result"}])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
… criando um novo gráfico para cada execução. Isso evita que a memória seja compartilhada entre os agentes e garante a independência do estado.