### PR TITLE
Expand env vars in config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Para mais detalhes sobre a arquitetura, consulte o [Documento de Arquitetura](Do
    - Copie o arquivo de exemplo: `cp .env.example .env`
    - Edite o arquivo `.env` e adicione suas chaves de API e credenciais.
 
+   O arquivo `config.yaml` suporta variáveis no formato `${VAR}`. Ao carregar as
+   configurações, esses padrões são substituídos pelos valores das variáveis de
+   ambiente correspondentes. Por exemplo, defina `NEO4J_PASSWORD` no `.env` para
+   preencher `services.neo4j_knowledge.password`.
+
 5. **Inicie os serviços de backend (Neo4j, MinIO):**
    ```bash
    docker-compose up -d

--- a/src/pro_vida/config/settings.py
+++ b/src/pro_vida/config/settings.py
@@ -1,3 +1,5 @@
+import os
+import re
 import yaml
 from pathlib import Path
 
@@ -8,7 +10,23 @@ def load_config():
     config_path = Path(__file__).parent.parent.parent.parent / 'config.yaml'
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
-    return config
+
+    def expand(value):
+        if isinstance(value, str):
+            pattern = re.compile(r"\$\{([^}]+)\}")
+
+            def repl(match):
+                var = match.group(1)
+                return os.environ.get(var, match.group(0))
+
+            return pattern.sub(repl, value)
+        elif isinstance(value, dict):
+            return {k: expand(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [expand(v) for v in value]
+        return value
+
+    return expand(config)
 
 # Carrega a configuração globalmente para que outros módulos possam importá-la
 settings = load_config()

--- a/src/pro_vida/tests/test_config.py
+++ b/src/pro_vida/tests/test_config.py
@@ -1,0 +1,16 @@
+import unittest
+from unittest.mock import patch
+import os
+
+class TestLoadConfig(unittest.TestCase):
+    @patch.dict(os.environ, {"NEO4J_PASSWORD": "secret"})
+    def test_env_var_expansion(self):
+        from pro_vida.config.settings import load_config
+        cfg = load_config()
+        self.assertEqual(
+            cfg["services"]["neo4j_knowledge"]["password"],
+            "secret"
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand environment variable expressions when loading `config.yaml`
- document env var expansion in README
- test that env vars are replaced in the loaded configuration

## Testing
- `PYTHONPATH=src python -m unittest discover -s src/pro_vida/tests` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6885cef274748329a0942e12cf8de7ba