### PR TITLE
Implement critical config improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ GOOGLE_API_KEY=SUA_CHAVE_API_DO_GOOGLE_AQUI
 NEO4J_PASSWORD=senha_super_segura_para_neo4j
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minio_senha_super_segura
+MINIO_BUCKET_NAME=provida-bucket
 
 # --- Configurações da Aplicação (lidas pelo Pydantic) ---
 # Use o delimitador duplo underscore (__) para estruturas aninhadas.

--- a/config.yaml
+++ b/config.yaml
@@ -59,13 +59,6 @@ search:
     interval: 3600  # Interval in seconds between automation runs
     daily_update_cron: "0 5 * * *" # Daily update at 5 AM
     quarterly_review_cron: "0 6 1 */3 *" # Quarterly review on 1st day of Jan, Apr, Jul, Oct at 6 AM
-    tasks:
-      - name: task1
-        description: "Description of task1"
-        enabled: true
-      - name: task2
-        description: "Description of task2"
-        enabled: false
 
 # Logging Configuration
 logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       # Monta o código-fonte para desenvolvimento em tempo real
       - ./src:/app/src
+    command: ["python", "-m", "src.main"]
     depends_on:
       - neo4j
       - minio

--- a/env_example_updates.md
+++ b/env_example_updates.md
@@ -13,6 +13,8 @@
   - **Value:** Replace `minioadmin` with a secure access key for MinIO.
 - **MinIO Secret Key:** `MINIO_SECRET_KEY`
   - **Value:** Replace `minio_senha_super_segura` with a secure secret key for MinIO.
+- **MinIO Bucket Name:** `MINIO_BUCKET_NAME`
+  - **Value:** Name of the bucket to be created in MinIO (e.g., `provida-bucket`).
 
 ### Database Configurations
 - **Neo4j Knowledge URI:** `DATABASE__NEO4J_KNOWLEDGE__URI`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,23 @@
-google-generativeai
-langgraph
-google-cloud-aiplatform
-python-dotenv
-pyyaml
-neo4j
-minio
-chromadb
-docker
-requests
-beautifulsoup4
-pypdf2
-rich # Para uma CLI mais bonita
-pydantic
-APScheduler
-fpdf2
-python-docx
+# LLM and AI
+google-generativeai==0.2.2
+langgraph==0.0.14
+google-cloud-aiplatform==1.38.0
+
+# Core utilities
+python-dotenv==1.0.0
+pyyaml==6.0
+requests==2.31.0
+beautifulsoup4==4.12.2
+pypdf2==3.0.1
+rich==13.5.2
+pydantic==2.6.4
+APScheduler==3.10.4
+fpdf2==2.7.8
+python-docx==1.1.0
+
+# Databases and storage
+neo4j==5.18.0
+minio==7.1.16
+chromadb==0.4.14
+docker==7.0.0
+

--- a/src/main.py
+++ b/src/main.py
@@ -3,9 +3,6 @@ import asyncio
 from src.app.scheduler_service import SchedulerService
 from src.app.config.logging_config import setup_logging
 
-# Setup logging (will be replaced by setup_logging() call)
-# logging.basicConfig(filename='main.log', level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 def main() -> None:
     """
     Main function to run the application, including the scheduler.


### PR DESCRIPTION
## Summary
- add runtime command for `provida-app`
- introduce `MINIO_BUCKET_NAME` in `.env.example`
- document MINIO bucket variable
- clean up automation tasks in `config.yaml`
- remove unused support doc
- pin requirements versions
- tidy main entrypoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6886ce2b1094832999a608b8699b60a8